### PR TITLE
Added wiremock extension for remote servers

### DIFF
--- a/wiremock-graphql-extension/pom.xml
+++ b/wiremock-graphql-extension/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <gpg.skip>true</gpg.skip>
         <kotlin.version>1.8.20</kotlin.version>
         <junit.version>5.9.2</junit.version>
@@ -189,6 +189,22 @@
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                         <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                 </configuration>
             </plugin>
         </plugins>

--- a/wiremock-graphql-extension/src/main/kotlin/io/github/nilwurtz/GraphqlBodyMatcher.kt
+++ b/wiremock-graphql-extension/src/main/kotlin/io/github/nilwurtz/GraphqlBodyMatcher.kt
@@ -11,7 +11,7 @@ import org.json.JSONException
 import org.json.JSONObject
 
 
-class GraphqlBodyMatcher private constructor() : RequestMatcherExtension() {
+class GraphqlBodyMatcher() : RequestMatcherExtension() {
 
     companion object {
         /**
@@ -99,12 +99,19 @@ class GraphqlBodyMatcher private constructor() : RequestMatcherExtension() {
             throw InvalidQueryException("Invalid request query: ${e.message}")
         }
 
-        val expectedQuery = try {
+        val expectedQuery =  if (parameters.containsKey("expectedQuery")) {
+            expectedRequestJson = JSONObject(parameters.getString("expectedQuery"))
             expectedRequestJson.getString("query")
                 .let { Parser().parseDocument(it) }
                 .let { GraphqlQueryNormalizer.normalizeGraphqlDocument(it) }
-        } catch (e: Exception) {
-            throw InvalidQueryException("Invalid expected query: ${e.message}")
+        } else {
+            try {
+                expectedRequestJson.getString("query")
+                    .let { Parser().parseDocument(it) }
+                    .let { GraphqlQueryNormalizer.normalizeGraphqlDocument(it) }
+           } catch (e: Exception) {
+               throw InvalidQueryException("Invalid expected query: ${e.message}")
+           }
         }
 
         // Extract and compare variables

--- a/wiremock-graphql-extension/src/test/kotlin/io/github/nilwurtz/GraphqlBodyMatcherTest.kt
+++ b/wiremock-graphql-extension/src/test/kotlin/io/github/nilwurtz/GraphqlBodyMatcherTest.kt
@@ -3,6 +3,7 @@ package io.github.nilwurtz
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.extension.Parameters
 import io.github.nilwurtz.exceptions.InvalidJsonException
 import io.github.nilwurtz.exceptions.InvalidQueryException
 import io.mockk.every
@@ -15,6 +16,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("queries are identical")
     fun testMatchedIdentical() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         // language=json
         val json = """
             {
@@ -23,7 +25,8 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns json
-        val actual = GraphqlBodyMatcher.withRequestJson(json).match(request, mockk())
+        every { parameters.containsKey("expectedQuery") } returns false
+        val actual = GraphqlBodyMatcher.withRequestJson(json).match(request, parameters)
         assertTrue(actual.isExactMatch)
     }
 
@@ -31,6 +34,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("test `withRequest` when queries are identical")
     fun testMatchedIdenticalWithRequest() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         val query = "{ hero { name friends { name }}}"
         // language=json
         val json = """
@@ -40,7 +44,8 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns json
-        val actual = GraphqlBodyMatcher.withRequestQueryAndVariables(query).match(request, mockk())
+        every { parameters.containsKey("expectedQuery") } returns false
+        val actual = GraphqlBodyMatcher.withRequestQueryAndVariables(query).match(request, parameters)
         assertTrue(actual.isExactMatch)
     }
 
@@ -48,6 +53,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("test `withRequest` when queries and variables are identical")
     fun testMatchedIdenticalWithRequestAndVariables() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         val query = "query GetCharacters(\$ids: [ID!]) { characters(ids: \$ids) { name age } }"
         val variables = """{"ids": [1, 2, 3]}"""
         val escaped = "\$ids"
@@ -66,7 +72,8 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns json
-        val actual = GraphqlBodyMatcher.withRequestQueryAndVariables(query, variables).match(request, mockk())
+        every { parameters.containsKey("expectedQuery") } returns false
+        val actual = GraphqlBodyMatcher.withRequestQueryAndVariables(query, variables).match(request, parameters)
         assertTrue(actual.isExactMatch)
     }
 
@@ -74,6 +81,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("query has different order in single level")
     fun testMatchedDifferentOrderSingleLevel() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         // language=JSON
         val requestJson = """
             {
@@ -88,7 +96,8 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns requestJson
-        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, mockk())
+        every { parameters.containsKey("expectedQuery") } returns false
+        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, parameters)
         assertTrue(actual.isExactMatch)
     }
 
@@ -97,6 +106,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("graphql query has different order so nested")
     fun testMatchedDifferentOrderNested() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         // language=JSON
         val requestJson = """
             {
@@ -111,8 +121,9 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns requestJson
+        every { parameters.containsKey("expectedQuery") } returns false
 
-        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, mockk())
+        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, parameters)
         assertTrue(actual.isExactMatch)
     }
 
@@ -120,6 +131,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("query has different depth")
     fun testUnmatchedDifferentDepth() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         // language=json
         val requestJson = """
             {
@@ -134,8 +146,9 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns requestJson
+        every { parameters.containsKey("expectedQuery") } returns false
 
-        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, mockk())
+        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, parameters)
         assertFalse(actual.isExactMatch)
     }
 
@@ -143,6 +156,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("query is missing a field")
     fun testUnmatchedMissingField() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         // language=json
         val requestJson = """
             {
@@ -157,8 +171,9 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns requestJson
+        every { parameters.containsKey("expectedQuery") } returns false
 
-        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, mockk())
+        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, parameters)
         assertFalse(actual.isExactMatch)
     }
 
@@ -166,6 +181,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("query has additional field")
     fun testUnmatchedAdditionalField() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         // language=json
         val requestJson = """
             {
@@ -180,8 +196,9 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns requestJson
+        every { parameters.containsKey("expectedQuery") } returns false
 
-        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, mockk())
+        val actual = GraphqlBodyMatcher.withRequestJson(expectedJson).match(request, parameters)
         assertFalse(actual.isExactMatch)
     }
 
@@ -189,6 +206,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("query has different field name")
     fun testUnmatchedDifferentFieldName() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         // language=json
         val json1 = """
             {
@@ -203,8 +221,9 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns json1
+        every { parameters.containsKey("expectedQuery") } returns false
 
-        val actual = GraphqlBodyMatcher.withRequestJson(json2).match(request, mockk())
+        val actual = GraphqlBodyMatcher.withRequestJson(json2).match(request, parameters)
         assertFalse(actual.isExactMatch)
     }
 
@@ -212,6 +231,7 @@ class GraphqlBodyMatcherTest {
     @DisplayName("query is invalid JSON")
     fun testUnmatchedInvalidJson() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         // language=json
         val invalidQuery = """
             {
@@ -220,9 +240,10 @@ class GraphqlBodyMatcherTest {
         """.trimIndent()
 
         every { request.bodyAsString } returns invalidQuery
+        every { parameters.containsKey("expectedQuery") } returns false
 
         assertThrows<InvalidQueryException> {
-            GraphqlBodyMatcher.withRequestJson(invalidQuery).match(request, mockk())
+            GraphqlBodyMatcher.withRequestJson(invalidQuery).match(request, parameters)
         }
     }
 
@@ -230,9 +251,11 @@ class GraphqlBodyMatcherTest {
     @DisplayName("json is empty")
     fun testUnmatchedEmptyJson() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         val emptyJson = ""
 
         every { request.bodyAsString } returns emptyJson
+        every { parameters.containsKey("expectedQuery") } returns false
 
         assertThrows<InvalidJsonException> {
             GraphqlBodyMatcher.withRequestJson(emptyJson).match(request, mockk())
@@ -243,12 +266,14 @@ class GraphqlBodyMatcherTest {
     @DisplayName("query is empty")
     fun testUnmatchedEmptyQuery() {
         val request = mockk<Request>()
+        val parameters = mockk<Parameters>()
         val json = """{ "query": "" }"""
 
         every { request.bodyAsString } returns json
+        every { parameters.containsKey("expectedQuery") } returns false
 
         assertThrows<InvalidQueryException> {
-            GraphqlBodyMatcher.withRequestJson(json).match(request, mockk())
+            GraphqlBodyMatcher.withRequestJson(json).match(request, parameters)
         }
     }
 


### PR DESCRIPTION
# Added wiremock extension for remote servers.


## Motivation

When using the wiremock Docker image, wiremock is started as a remote server.
The current implementation of extensions in this repository only supports local invocation of wiremock (eg within a test runner). We want to use this extension on our wiremock remote server as well.

## What changes did you make?

- GraphqlBodyMatcher's match method now checks `parameters: Parameter` (this allows the remote server to communicate with the local client via Parameter)
- Updated jvmTarget to 1.8. This is for compatibility in the execution environment because the wiremock image assumes jre8 :)
- Added maven-assembly-plugin. This will create a jar with all dependencies when you run `mvn package`. The reason for this is that it is convenient to make the remote wiremock server aware
- I wanted the unit test to pass, so I changed it (`mockk<Parameter>`)

## About what we tested

- `mvn package`
- On docker, include jar in wiremock and start the container
```bash
FROM wiremock/wiremock:latest-alpine
COPY ./wiremock-graphql-extension-0.3.0-jar-with-dependencies.jar /var/wiremock/extensions/wiremock-graphql-extension-0.3.0-jar-with-dependencies.jar
CMD ["--verbose", "--enable-stub-cors", "--extensions", "io.github.nilwurtz.GraphqlBodyMatcher"]
```
- register GraphqlBodyMatcher in test code
```kotlin
import com.github.tomakehurst.wiremock.client.WireMock
import com.github.tomakehurst.wiremock.client.WireMock.*
import kotlinx.serialization.Serializable
import kotlinx.serialization.encodeToString
import kotlinx.serialization.json.Json

fun registerGraphQLWiremock(endpoint: String, token: String, request: Request, responseJson:  String) {
     post(urlPathEqualTo(endPoint))
        .withQueryParam("access_token", matching(token))
        .andMatching("graphql-body-matcher", Parameters.one("expectedQuery", Json.encodeToString(request)))
        .willReturn(
            aResponse()
                 .withStatus(200)
                 .withBody(responseJson)
                 .withHeader("Content-Type", "application/json; charset=utf-8")
     ).let(mock::register)
}
```
- run test

powered by Google Translate

------

# [日本語] リモートサーバー用のワイヤーモック拡張機能を追加


## モチベーション

wiremockのDockerイメージを使う場合、wiremockはリモートサーバーとして起動します。
現在のこのリポジトリのエクステンション実装はwiremockのローカル起動(例テストランナー内での起動)の場合のみしかサポートしていません。我々はwiremockのリモートサーバーでもこのエクステンションを使用したいです。

## どのような変更をあなたは加えました?

- GraphqlBodyMatcherのmatchメソッドで`parameters: Parameter` をチェックするようにしました(これにより、リモートサーバーはParameterを介してローカルのクライアントとコミュニケーション出来ます)
- jvmTargetを1.8にしました。これは、wiremockのimageがjre8を前提としているため実行環境での互換性のためです :)
- maven-assembly-pluginを追加しました。これにより、`mvn package`実行時に依存関係を全て含んだjarを作成します。これの理由は、remoteのwiremockサーバーに認識させるのに都合が良いためです
- ユニットテストがPASSしたかったので、変更をしました(`mockk<Parameter>`)

## テストした内容について

- `maven package`
- docker上で、wiremockにjarを含めてコンテナ起動
```bash
FROM wiremock/wiremock:latest-alpine
COPY ./wiremock-graphql-extension-0.3.0-jar-with-dependencies.jar /var/wiremock/extensions/wiremock-graphql-extension-0.3.0-jar-with-dependencies.jar
CMD ["--verbose", "--enable-stub-cors", "--extensions", "io.github.nilwurtz.GraphqlBodyMatcher"]
```
- テストコードでGraphqlBodyMatcherをregister
```kotlin
import com.github.tomakehurst.wiremock.client.WireMock
import com.github.tomakehurst.wiremock.client.WireMock.*
import kotlinx.serialization.Serializable
import kotlinx.serialization.encodeToString
import kotlinx.serialization.json.Json

fun registerGraphQLWiremock(endpoint: String, token: String, request: Request, responseJson:  String) {
     post(urlPathEqualTo(endPoint))
        .withQueryParam("access_token", matching(token))
        .andMatching("graphql-body-matcher", Parameters.one("expectedQuery", Json.encodeToString(request)))
        .willReturn(
            aResponse()
                 .withStatus(200)
                 .withBody(responseJson)
                 .withHeader("Content-Type", "application/json; charset=utf-8")
     ).let(mock::register)
}
```
- テストを実行してPASS

